### PR TITLE
Minor fix:  CA-root documentation link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ PASSWORD=<PASSWORD>
 MYSQL_ATTR_SSL_CA=
 ```
 
-5. For `MYSQL_ATTR_SSL_CA`, use our [CA root configuration doc](/concepts/secure-connections#ca-root-configuration) to find the correct value for your system. For example, if you're on MacOS, it would be:
+5. For `MYSQL_ATTR_SSL_CA`, use our [CA root configuration doc](https://docs.planetscale.com/concepts/secure-connections#ca-root-configuration) to find the correct value for your system. For example, if you're on MacOS, it would be:
 
 ```
 MYSQL_ATTR_SSL_CA=/etc/ssl/cert.pem


### PR DESCRIPTION
Thanks for this. 

However, while consuming the repo, I noticed the link to the Planetscale CA root configuration doc is broken;  navigating to 404 Github repo page. 

Kindly check and compare.